### PR TITLE
Fix ZSH_CUSTOM path

### DIFF
--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -1,7 +1,7 @@
 # Path to your oh-my-zsh configuration.
 ZSH=$HOME/.oh-my-zsh
 
-ZSH_CUSTOM=$HOME/.dotfiles/misc/oh-my-zsh-custom/themes
+ZSH_CUSTOM=$HOME/.dotfiles/misc/oh-my-zsh-custom
 
 # Set name of the theme to load.
 # Look in ~/.oh-my-zsh/themes/


### PR DESCRIPTION
Some plugins use the `ZSH_CUSTOM` var for their install scripts causing you to end up with something like this:
```
misc
└── oh-my-zsh-custom
    └── themes
        └── agnoster.zsh-theme
        └── plugins
            └── my_plugin
                └── my_plugin.plugin.zsh

```

As described in https://github.com/robbyrussell/oh-my-zsh/wiki/Customization `ZSH_CUSTOM` should point to a parent directory containing both the `themes` and `plugins` directory.
