### PR TITLE
always install latest composer version

### DIFF
--- a/installscript
+++ b/installscript
@@ -41,10 +41,21 @@ chmod +x z.sh
 echo 'Install composer'
 echo '----------------'
 cd ~/.dotfiles
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-php composer-setup.php
-php -r "unlink('composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+rm -f composer-setup.php
+
 echo 'move composer to /usr/local/bin/composer'
 mv -f composer.phar /usr/local/bin/composer
 


### PR DESCRIPTION
Accordingly from`https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md`,
the installer script contains a signature which changes when the installer code changes and as such it should not be relied upon in the long term.

This PR solves this problem by fetching the latest composer signature every time.