### PR TITLE
Update history ignore export for ZSH

### DIFF
--- a/shell/.exports
+++ b/shell/.exports
@@ -7,6 +7,8 @@ export HISTFILESIZE=$HISTSIZE
 export HISTCONTROL=ignoredups
 # Make some commands not show up in history
 export HISTIGNORE="ls:cd:cd -:pwd:exit:date:* --help"
+# An include the parameter for ZSH
+export HISTORY_IGNORE="(ls|cd|cd -|pwd|exit|date|* --help)"
 
 # Prefer US English and use UTF-8
 export LANG="en_US.UTF-8"

--- a/shell/.exports
+++ b/shell/.exports
@@ -7,7 +7,7 @@ export HISTFILESIZE=$HISTSIZE
 export HISTCONTROL=ignoredups
 # Make some commands not show up in history
 export HISTIGNORE="ls:cd:cd -:pwd:exit:date:* --help"
-# An include the parameter for ZSH
+# And include the parameter for ZSH
 export HISTORY_IGNORE="(ls|cd|cd -|pwd|exit|date|* --help)"
 
 # Prefer US English and use UTF-8


### PR DESCRIPTION
ZSH uses a different parameter to hold commands that will be ignored. (See http://zsh.sourceforge.net/Doc/Release/Parameters.html#Parameters-Used-By-The-Shell)