### PR TITLE
Don't break composer install on new version

### DIFF
--- a/installscript
+++ b/installscript
@@ -41,18 +41,20 @@ chmod +x z.sh
 echo 'Install composer'
 echo '----------------'
 cd ~/.dotfiles
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-php composer-setup.php
-php -r "unlink('composer-setup.php');"
-echo 'move composer to /usr/local/bin/composer'
-mv -f composer.phar /usr/local/bin/composer
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
 
-php composer-setup.php --quiet
-rm -f composer-setup.php
-
-echo 'move composer to /usr/local/bin/composer'
-mv -f composer.phar /usr/local/bin/composer
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    echo 'ERROR: Invalid Composer installer signature'
+    rm composer-setup.php
+else
+    php composer-setup.php --quiet
+    rm composer-setup.php
+    echo 'move composer to /usr/local/bin/composer'
+    sudo mv -f composer.phar /usr/local/bin/composer
+fi
 
 echo 'Install homebrew'
 echo '----------------'


### PR DESCRIPTION
Every time composer releases a new version, the signature changes (which will break this script).

There's an alternative, as stated in the composer docs:
https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md

This code was altered so it doesn't exit on failure and still installs the remaning software.