### PR TITLE
add -G flag to ls command

### DIFF
--- a/shell/.aliases
+++ b/shell/.aliases
@@ -30,7 +30,7 @@ alias glog="git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset
 alias o="open ."
 
 # List all files colorized in long format
-alias l="ls -laF"
+alias l="ls -laFG"
 
 # PhPStorm
 alias phpstorm='open -a /Applications/PhpStorm.app "`pwd`"'


### PR DESCRIPTION
ls command needs `-G` flag to enable colorized output