### PR TITLE
Add Mackup to ignored applications

### DIFF
--- a/macos/.mackup.cfg
+++ b/macos/.mackup.cfg
@@ -3,4 +3,5 @@ engine = dropbox
 
 [applications_to_ignore]
 illustrator
+mackup
 zsh


### PR DESCRIPTION
If you don't ignore Mackup, whenever you run a backup, the ~/.mackup.cfg is re-symlinked to the .mackup.cfg file within your Mackup backup. I believe it's best to keep your Mackup config stored and referenced in your .dotfiles for updating/versioning.