### PR TITLE
Better PHP switcher

### DIFF
--- a/shell/.functions
+++ b/shell/.functions
@@ -1,19 +1,20 @@
 # Switch PHP versions
 phpv() {
-    valet stop
-    brew unlink php@7.0 php@7.1 php@7.2 php@7.3 php@7.4
-    brew link --force --overwrite $1
-    brew services start $1
+    if [ $1 = "7.4" ]; then
+        valet use php
+    else
+        valet use php@$1
+    fi
+    sed -in "s/128M/512M/g" /usr/local/etc/php/$1/conf.d/php-memory-limits.ini
     composer global update
-    rm -f ~/.config/valet/valet.sock
-    valet install
+    source ~/.zshrc
 }
 
-alias php70="phpv php@7.0"
-alias php71="phpv php@7.1"
-alias php72="phpv php@7.2"
-alias php73="phpv php@7.3"
-alias php74="phpv php@7.4"
+alias php70="phpv 7.0"
+alias php71="phpv 7.1"
+alias php72="phpv 7.2"
+alias php73="phpv 7.3"
+alias php74="phpv 7.4"
 
 
 # Create a new directory and enter it


### PR DESCRIPTION
- Valet has a `valet use <version>` command now, that checks brew and switches PHP versions automatically.
- Valet also sets a default of 128M for the memory_limits, so we want to replace this by something a bit higher using `sed`