### PR TITLE
List databases

### DIFF
--- a/shell/.functions
+++ b/shell/.functions
@@ -99,6 +99,8 @@ function db {
         mysql -uroot -e "create database $2"
     elif [ "$1" = "drop" ]; then
         mysql -uroot -e "drop database $2"
+    elif [ "$1" = "list" ]; then
+        mysql -uroot -e "show databases" | perl -p -e's/\|| *//g'
     fi
 }
 


### PR DESCRIPTION
I added a `db list` very useful when you want to check your database's and do some cleanup or some other shell manipulations.

Listing databases and filtering the ones named tenant
```
db list | grep tenant
```

Could list something similar to:
```
tenant_01
tenant_02
tenant_03
```

A cleanup example: 
```
db list | grep tenant | for i in $(cat); do db drop $i; done;
```