### PR TITLE
Rename OSX plugin to macOS

### DIFF
--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -15,7 +15,7 @@ DEFAULT_USER=`whoami`
 # Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
-plugins=(git laravel4 laravel5 composer osx vagrant)
+plugins=(git laravel4 laravel5 composer macos vagrant)
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
Update oh my zsh plugin name from osx to macos. https://github.com/ohmyzsh/ohmyzsh/pull/10341