### PR TITLE
Fix PHP support for macOS Monterey

### DIFF
--- a/installscript
+++ b/installscript
@@ -87,7 +87,9 @@ brew install --cask qlcolorcode qlstephen qlmarkdown quicklook-json qlprettypatc
 
 echo 'Install php'
 echo '-----------'
-brew install php@8.0
+brew tap shivammathur/php
+brew install shivammathur/php/php@8.0
+brew link --overwrite --force php@8.0
 
 echo 'Install composer'
 echo '----------------'


### PR DESCRIPTION
The latest macOS version Monterey 12 has removed PHP altogether from its operating system. 

This article explains it better.

[https://wpbeaches.com/updating-to-php-versions-7-4-and-8-on-macos-12-monterey/](https://wpbeaches.com/updating-to-php-versions-7-4-and-8-on-macos-12-monterey/)