### PR TITLE
Update commit function

### DIFF
--- a/shell/.functions
+++ b/shell/.functions
@@ -94,7 +94,7 @@ function rector() {
 
 #  Commit everything
 function commit() {
-  commitMessage="$1"
+  commitMessage="$*"
 
   if [ "$commitMessage" = "" ]; then
      commitMessage="wip"


### PR DESCRIPTION
Allows writing commits with or without quotes (e.g. `commit This is a commit message` instead of `commit "this is a commit message"`)