### PR TITLE
Removing the dot

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -4,7 +4,7 @@
 
 function bootstrapTerminal() {	
 	sudo -v #ask password beforehand
-	source ~/.dotfiles/installscript
+	source ~/dotfiles/installscript
 }
 
 


### PR DESCRIPTION
Removing the dot, because after cloning the repository there's not dot in the directory, making the script to not run.