### PR TITLE
Removes conflicting VSCode cli command

### DIFF
--- a/shell/.aliases
+++ b/shell/.aliases
@@ -47,9 +47,6 @@ alias switch-php74="brew unlink php && brew link --overwrite --force php@7.4"
 # Redis
 alias flush-redis="redis-cli FLUSHALL"
 
-# VSCode
-alias code='open -a "/Applications/Visual Studio Code.app" "`pwd`"'
-
 # Show/hide hidden files in Finder
 alias show="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"
 alias hide="defaults write com.apple.finder AppleShowAllFiles -bool false && killall Finder"


### PR DESCRIPTION
VSCode has an existing cli command `code` which this command conflicts with. The default command installed with VSCode allows you to open code from any dir.

E.g `code .` would open the pwd or `code ~/Code` would open the Code dir.

https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line

With this alias it will always open from the current directory