### PR TITLE
Update commit message generation command

### DIFF
--- a/home/.functions
+++ b/home/.functions
@@ -59,7 +59,7 @@ function commit() {
 
      # Get diff with size limit, include stat summary for context
      diff_input=$(echo "=== Summary ===" && git diff --cached --stat && echo -e "\n=== Diff (truncated if large) ===" && git diff --cached | head -c 50000)
-     commitMessage=$(echo "$diff_input" | claude -p "Write a single-line commit message for this diff. Output ONLY the message, no quotes, no explanation, no markdown.")
+     commitMessage=$(echo "$diff_input" | claude -p --no-session-persistence "Write a single-line commit message for this diff. Output ONLY the message, no quotes, no explanation, no markdown.")
 
      # Stop spinner and clear line
      trap - INT


### PR DESCRIPTION
Add `--no-session-persistence` to the `claude` call in the `commit` function. Without it, the commit fails with: `Aborting commit due to empty commit message.`